### PR TITLE
Allow for empty HTTP passwords

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -53,7 +53,7 @@ class auth_plugin_authhttp extends DokuWiki_Auth_Plugin {
         /* Make sure that HTTP authentication has been enabled in the Web
            server. Note that does not seem to work with PHP >= 4.3.0 and safe
            mode enabled! */
-        if ($_SERVER['PHP_AUTH_USER'] == "" || $_SERVER['PHP_AUTH_PW'] == "") {
+        if ($_SERVER['PHP_AUTH_USER'] == "") {
             msg($this->getLang('nocreds'), -1);
             $this->success = false;
             return;


### PR DESCRIPTION
As best I can tell, an empty password is valid in HTTP authentication, so this change removes the check for an empty `PHP_AUTH_USER`.

Longer story: in our environment, the web server doesn't create the `PHP_AUTH_*` variables, only `REMOTE_USER`. The simplest way to get things working was to make this tweak and to assign `REMOTE_USER` to `PHP_AUTH_USER` in `local.protected.php`.

Thanks for your work regarding the new authentication system!
