### PR TITLE
Adding cleanUser function

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -130,7 +130,7 @@ class auth_plugin_authhttp extends DokuWiki_Auth_Plugin {
     public function cleanUser($user) {
         global $conf;
 
-        if $conf['strip_realm'] {
+        if ($conf['strip_realm']) {
             $exploded_user = explode("@", $user);
             return $exploded_user[0];
         }

--- a/auth.php
+++ b/auth.php
@@ -63,7 +63,7 @@ class auth_plugin_authhttp extends DokuWiki_Auth_Plugin {
         $this->loadConfig();
 
         /* Set the config values */
-        foreach (array("emaildomain", "specialusers", "specialgroup") as $cfgvar) {
+        foreach (array("emaildomain", "specialusers", "specialgroup", "strip_realm") as $cfgvar) {
             $this->$cfgvar = $this->getConf("$cfgvar");
             if (!$this->$cfgvar) {
                  msg("Config error: \"$cfgvar\" not set!", -1);
@@ -87,7 +87,11 @@ class auth_plugin_authhttp extends DokuWiki_Auth_Plugin {
      * @return  bool
      */
     public function checkPass($user, $pass) {
-        return ($user == $_SERVER['PHP_AUTH_USER'] && $pass == $_SERVER['PHP_AUTH_PW']);
+        $u = $_SERVER['PHP_AUTH_USER'];
+        if ($this->strip_realm) {
+            $u = array_shift(explode("@", $u));
+        }
+        return ($user == $u && $pass == $_SERVER['PHP_AUTH_PW']);
     }
 
     /**
@@ -128,17 +132,15 @@ class auth_plugin_authhttp extends DokuWiki_Auth_Plugin {
      *
      */
     public function cleanUser($user) {
-        global $conf;
-
-        if ($conf['strip_realm']) {
-            $exploded_user = explode("@", $user);
-            return $exploded_user[0];
+        if ($this->strip_realm) {
+            $exp_user = explode("@", $user);
+            return $exp_user[0];
         }
-
         else {
             return $user;
         }
     }
+
 
 }
 

--- a/auth.php
+++ b/auth.php
@@ -133,8 +133,7 @@ class auth_plugin_authhttp extends DokuWiki_Auth_Plugin {
      */
     public function cleanUser($user) {
         if ($this->strip_realm) {
-            $exp_user = explode("@", $user);
-            return $exp_user[0];
+            return array_shift(explode("@", $user));
         }
         else {
             return $user;

--- a/auth.php
+++ b/auth.php
@@ -115,6 +115,31 @@ class auth_plugin_authhttp extends DokuWiki_Auth_Plugin {
 
         return $info;
     }
+
+    /**
+     * Clean username
+     *
+     * If strip_realm is set to true,
+     * removes everything after @.
+     * Otherwise, returns input.
+     *
+     * @param    string $user the user name
+     * @return   string containing cleaned username
+     *
+     */
+    public function cleanUser($user) {
+        global $conf;
+
+        if $conf['strip_realm'] {
+            $exploded_user = explode("@", $user);
+            return $exploded_user[0];
+        }
+
+        else {
+            return $user;
+        }
+    }
+
 }
 
 // vim:ts=4:sw=4:et:

--- a/conf/default.php
+++ b/conf/default.php
@@ -8,4 +8,4 @@
 $conf['emaildomain']  = 'localhost';
 $conf['specialusers'] = 'youmustchangethis';
 $conf['specialgroup'] = 'admin';
-$conf['strip_realm'] = 0;
+$conf['strip_realm']  = 0;

--- a/conf/default.php
+++ b/conf/default.php
@@ -8,3 +8,4 @@
 $conf['emaildomain']  = 'localhost';
 $conf['specialusers'] = 'youmustchangethis';
 $conf['specialgroup'] = 'admin';
+$conf['strip_realm'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,4 +8,4 @@
 $meta['emaildomain']  = array('string');
 $meta['specialusers'] = array('string', '_cautionList' => array('plugin____authhttp____specialusers' => 'danger'));
 $meta['specialgroup'] = array('string', '_cautionList' => array('plugin____authhttp____specialgroup' => 'danger'));
-$meta['strip_realm'] = array('onoff', '_cautionList' => array('plugin____authhttp____specialgroup' => 'danger'));
+$meta['strip_realm']  = array('onoff', '_cautionList' => array('plugin____authhttp____specialgroup' => 'danger'));

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,3 +8,4 @@
 $meta['emaildomain']  = array('string');
 $meta['specialusers'] = array('string', '_cautionList' => array('plugin____authhttp____specialusers' => 'danger'));
 $meta['specialgroup'] = array('string', '_cautionList' => array('plugin____authhttp____specialgroup' => 'danger'));
+$meta['strip_realm'] = array('onoff', '_cautionList' => array('plugin____authhttp____specialgroup' => 'danger'));

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -10,6 +10,6 @@ $lang['plugin_settings_name'] = 'HTTP-Authentifizierungs-Plugin';
 $lang['emaildomain']  = 'Domain zur Erzeugung von E-Mail-Adressen';
 $lang['specialusers'] = 'Benutzernamen, die zur Spezialgruppe gehören';
 $lang['specialgroup'] = 'Name der Spezialgruppe';
-$lang['strip_realm'] = 'Alles nach dem "at-Zeichen" im Benutzernamen entfernen';
+$lang['strip_realm']  = 'Alles nach dem "at-Zeichen" im Benutzernamen entfernen';
 
 //Setup VIM: ex: et ts=4 :

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -10,5 +10,6 @@ $lang['plugin_settings_name'] = 'HTTP-Authentifizierungs-Plugin';
 $lang['emaildomain']  = 'Domain zur Erzeugung von E-Mail-Adressen';
 $lang['specialusers'] = 'Benutzernamen, die zur Spezialgruppe gehören';
 $lang['specialgroup'] = 'Name der Spezialgruppe';
+$lang['strip_realm'] = 'Alles nach dem "at-Zeichen" im Benutzernamen entfernen';
 
 //Setup VIM: ex: et ts=4 :

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -10,5 +10,6 @@ $lang['plugin_settings_name'] = 'HTTP authentication plugin';
 $lang['emaildomain']  = 'Domain to append for creating email addresses';
 $lang['specialusers'] = 'Usernames belonging to the special group';
 $lang['specialgroup'] = 'Name of the special group';
+$lang['strip_realm'] = 'Remove everything following @ from username';
 
 //Setup VIM: ex: et ts=4 :

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -10,6 +10,6 @@ $lang['plugin_settings_name'] = 'HTTP authentication plugin';
 $lang['emaildomain']  = 'Domain to append for creating email addresses';
 $lang['specialusers'] = 'Usernames belonging to the special group';
 $lang['specialgroup'] = 'Name of the special group';
-$lang['strip_realm'] = 'Remove everything following @ from username';
+$lang['strip_realm']  = 'Remove everything following @ from username';
 
 //Setup VIM: ex: et ts=4 :


### PR DESCRIPTION
I added a cleanUser function to this plugin, which is able to strip the realm from the end of the usernames passed to authhttp. This is useful, for instance, when using Kerberos as the authentication method on HTTP, as it returns REMOTE_USER with the realm on the end, which can cause some problems if you want to use something like authsplit and authldap for authorization.